### PR TITLE
v2.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,10 @@ Write retry logic for operations like web request or file operation in a more re
 Examples:
 -------
 
+````csharp
+using Retry;
+````
+
 ### One-line example
 ````csharp
 RetryHelper.Instance.Try(() => TryDoSomething()).UntilNoException();

--- a/RetryHelper.sln
+++ b/RetryHelper.sln
@@ -1,11 +1,13 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 2012
+# Visual Studio 14
+VisualStudioVersion = 14.0.25420.1
+MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "RetryHelper", "RetryHelper\RetryHelper.csproj", "{090FD2FF-7BC8-4213-946E-2ABFA1896F2F}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{EECF3997-89DF-4CED-9303-6B33A3EBC84B}"
 	ProjectSection(SolutionItems) = preProject
-		LICENSE.md = LICENSE.md
+		LICENSE = LICENSE
 		README.md = README.md
 	EndProjectSection
 EndProject

--- a/RetryHelper/AsyncRetryTask.cs
+++ b/RetryHelper/AsyncRetryTask.cs
@@ -42,6 +42,9 @@ namespace Retry
                 maxTryTime, maxTryCount, tryInterval);
         }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AsyncRetryTask"/> class.
+        /// </summary>
         protected AsyncRetryTask()
         {
         }
@@ -81,7 +84,7 @@ namespace Retry
         }
 
         /// <summary>
-        ///   Retries the task until the specified exception is not thrown during the task execution.
+        ///   Retries the task until the specified exception or any derived exception is not thrown during the task execution.
         ///   Any other exception thrown is re-thrown.
         /// </summary>
         /// <returns></returns>
@@ -89,6 +92,17 @@ namespace Retry
         public async Task UntilNoException<TException>()
         {
             await Task.UntilNoException<TException>();
+        }
+
+        /// <summary>
+        ///   Retries the task until the specified exception or any derived exception is not thrown during the task execution.
+        ///   Any other exception thrown is re-thrown.
+        /// </summary>
+        /// <returns></returns>
+        [DebuggerNonUserCode]
+        public async Task UntilNoException(Type exceptionType)
+        {
+            await Task.UntilNoException(exceptionType);
         }
 
         /// <summary>

--- a/RetryHelper/AsyncRetryTask.cs
+++ b/RetryHelper/AsyncRetryTask.cs
@@ -9,12 +9,9 @@ namespace Retry
     /// </summary>
     public class AsyncRetryTask
     {
-        public static readonly TimeSpan DefaultTryInterval = TimeSpan.FromMilliseconds(500);
-
-        public static readonly TimeSpan DefaultMaxTryTime = TimeSpan.MaxValue;
-
-        public static readonly int DefaultMaxTryCount = int.MaxValue;
-
+        /// <summary>
+        /// The underlying parameterized <see cref="AsyncRetryTask{T}"/> instance.
+        /// </summary>
         protected AsyncRetryTask<int> Task;
 
         /// <summary>

--- a/RetryHelper/AsyncRetryTask.cs
+++ b/RetryHelper/AsyncRetryTask.cs
@@ -162,7 +162,7 @@ namespace Retry
         /// <returns></returns>
         public AsyncRetryTask OnTimeout(Action timeoutAction)
         {
-            return new AsyncRetryTask { Task = Task.OnTimeout(t => timeoutAction()) };
+            return new AsyncRetryTask { Task = Task.OnTimeout(timeoutAction) };
         }
 
         /// <summary>
@@ -183,7 +183,7 @@ namespace Retry
         /// <returns></returns>
         public AsyncRetryTask OnTimeout(Func<Task> timeoutAction)
         {
-            return new AsyncRetryTask { Task = Task.OnTimeout(t => timeoutAction()) };
+            return new AsyncRetryTask { Task = Task.OnTimeout(timeoutAction) };
         }
 
         /// <summary>
@@ -204,7 +204,7 @@ namespace Retry
         /// <returns></returns>
         public AsyncRetryTask OnFailure(Action failureAction)
         {
-            return new AsyncRetryTask { Task = Task.OnFailure(t => failureAction()) };
+            return new AsyncRetryTask { Task = Task.OnFailure(failureAction) };
         }
 
         /// <summary>
@@ -225,7 +225,7 @@ namespace Retry
         /// <returns></returns>
         public AsyncRetryTask OnFailure(Func<Task> failureAction)
         {
-            return new AsyncRetryTask { Task = Task.OnFailure(t => failureAction()) };
+            return new AsyncRetryTask { Task = Task.OnFailure(failureAction) };
         }
 
         /// <summary>
@@ -246,7 +246,7 @@ namespace Retry
         /// <returns></returns>
         public AsyncRetryTask OnSuccess(Action successAction)
         {
-            return new AsyncRetryTask { Task = Task.OnSuccess(t => successAction()) };
+            return new AsyncRetryTask { Task = Task.OnSuccess(successAction) };
         }
 
         /// <summary>
@@ -267,7 +267,7 @@ namespace Retry
         /// <returns></returns>
         public AsyncRetryTask OnSuccess(Func<Task> successAction)
         {
-            return new AsyncRetryTask { Task = Task.OnSuccess(t => successAction()) };
+            return new AsyncRetryTask { Task = Task.OnSuccess(successAction) };
         }
 
         /// <summary>

--- a/RetryHelper/AsyncRetryTaskOfT.cs
+++ b/RetryHelper/AsyncRetryTaskOfT.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Diagnostics;
 using System.Globalization;
-using System.Threading;
 using System.Threading.Tasks;
 
 namespace Retry

--- a/RetryHelper/AsyncRetryTaskOfT.cs
+++ b/RetryHelper/AsyncRetryTaskOfT.cs
@@ -217,6 +217,16 @@ namespace Retry
         }
 
         /// <summary>
+        /// Configures the action to take when the try action timed out before success.
+        /// </summary>
+        /// <param name="timeoutAction">The action to take on timeout.</param>
+        /// <returns></returns>
+        public AsyncRetryTask<T> OnTimeout(Action timeoutAction)
+        {
+            return OnTimeout((result, tryCount) => timeoutAction());
+        }
+
+        /// <summary>
         /// Configures the action to take when the try action timed out before success. 
         /// The result of the last failed attempt is passed as parameter to the action.
         /// For <see cref="UntilNoException"/>, the parameter passed to the action 
@@ -226,9 +236,8 @@ namespace Retry
         /// <returns></returns>
         public AsyncRetryTask<T> OnTimeout(Action<T> timeoutAction)
         {
-            var retryTask = Clone();
-            retryTask.OnTimeoutAction += (result, tryCount) => Task.Run(() => timeoutAction(result));
-            return retryTask;
+            return OnTimeout((result, tryCount) => timeoutAction(result));
+
         }
 
         /// <summary>
@@ -242,13 +251,21 @@ namespace Retry
         /// <returns></returns>
         public AsyncRetryTask<T> OnTimeout(Action<T, int> timeoutAction)
         {
-            var retryTask = Clone();
-            retryTask.OnTimeoutAction += (result, tryCount) => Task.Run(() => timeoutAction(result, tryCount));
-            return retryTask;
+            return OnTimeout((result, tryCount) => Task.Run(() => timeoutAction(result, tryCount)));
         }
 
         /// <summary>
-        /// Configures the action to take when the try action timed out before success. 
+        /// Configures the asynchronous action to take when the try action timed out before success.
+        /// </summary>
+        /// <param name="timeoutAction">The action to take on timeout.</param>
+        /// <returns></returns>
+        public AsyncRetryTask<T> OnTimeout(Func<Task> timeoutAction)
+        {
+            return OnTimeout((result, tryCount) => timeoutAction());
+        }
+
+        /// <summary>
+        /// Configures the asynchronous action to take when the try action timed out before success. 
         /// The result of the last failed attempt is passed as parameter to the action.
         /// For <see cref="UntilNoException"/>, the parameter passed to the action 
         /// is always <c>default(T)</c>
@@ -257,13 +274,11 @@ namespace Retry
         /// <returns></returns>
         public AsyncRetryTask<T> OnTimeout(Func<T, Task> timeoutAction)
         {
-            var retryTask = Clone();
-            retryTask.OnTimeoutAction += (result, tryCount) => timeoutAction(result);
-            return retryTask;
+            return OnTimeout((result, tryCount) => timeoutAction(result));
         }
 
         /// <summary>
-        /// Configures the action to take when the try action timed out before success. 
+        /// Configures the asynchronous action to take when the try action timed out before success. 
         /// The result of the last failed attempt and the total count of attempts 
         /// are passed as parameters to the action.
         /// For <see cref="UntilNoException"/>, the parameter passed to the action 
@@ -280,15 +295,23 @@ namespace Retry
 
         /// <summary>
         /// Configures the action to take after each time the try action fails and before the next try. 
+        /// </summary>
+        /// <param name="failureAction">The action to take on failure.</param>
+        /// <returns></returns>
+        public AsyncRetryTask<T> OnFailure(Action failureAction)
+        {
+            return OnFailure((result, tryCount) => failureAction());
+        }
+
+        /// <summary>
+        /// Configures the action to take after each time the try action fails and before the next try. 
         /// The result of the failed try action will be passed as parameter to the action.
         /// </summary>
         /// <param name="failureAction">The action to take on failure.</param>
         /// <returns></returns>
         public AsyncRetryTask<T> OnFailure(Action<T> failureAction)
         {
-            var retryTask = Clone();
-            retryTask.OnFailureAction += (result, tryCount) => Task.Run(() => failureAction(result));
-            return retryTask;
+            return OnFailure((result, tryCount) => failureAction(result));
         }
 
         /// <summary>
@@ -300,13 +323,21 @@ namespace Retry
         /// <returns></returns>
         public AsyncRetryTask<T> OnFailure(Action<T, int> failureAction)
         {
-            var retryTask = Clone();
-            retryTask.OnFailureAction += (result, tryCount) => Task.Run(() => failureAction(result, tryCount));
-            return retryTask;
+            return OnFailure((result, tryCount) => Task.Run(() => failureAction(result, tryCount)));
         }
 
         /// <summary>
-        /// Configures the action to take after each time the try action fails and before the next try. 
+        /// Configures the asynchronous action to take after each time the try action fails and before the next try. 
+        /// </summary>
+        /// <param name="failureAction">The action to take on failure.</param>
+        /// <returns></returns>
+        public AsyncRetryTask<T> OnFailure(Func<Task> failureAction)
+        {
+            return OnFailure((result, tryCount) => failureAction());
+        }
+
+        /// <summary>
+        /// Configures the asynchronous action to take after each time the try action fails and before the next try. 
         /// The result of the failed try action and the total count of attempts that 
         /// have been performed are passed as parameters to the action.
         /// </summary>
@@ -314,13 +345,11 @@ namespace Retry
         /// <returns></returns>
         public AsyncRetryTask<T> OnFailure(Func<T, Task> failureAction)
         {
-            var retryTask = Clone();
-            retryTask.OnFailureAction += (result, tryCount) => failureAction(result);
-            return retryTask;
+            return OnFailure((result, tryCount) => failureAction(result));
         }
 
         /// <summary>
-        /// Configures the action to take after each time the try action fails and before the next try. 
+        /// Configures the asynchronous action to take after each time the try action fails and before the next try. 
         /// The result of the failed try action and the total count of attempts that 
         /// have been performed are passed as parameters to the action.
         /// </summary>
@@ -335,15 +364,23 @@ namespace Retry
 
         /// <summary>
         /// Configures the action to take when the try action succeeds.
+        /// </summary>
+        /// <param name="successAction">The action to take on success.</param>
+        /// <returns></returns>
+        public AsyncRetryTask<T> OnSuccess(Action successAction)
+        {
+            return OnSuccess((result, tryCount) => successAction());
+        }
+
+        /// <summary>
+        /// Configures the action to take when the try action succeeds.
         /// The result of the successful attempt is passed as parameter to the action.
         /// </summary>
         /// <param name="successAction">The action to take on success.</param>
         /// <returns></returns>
         public AsyncRetryTask<T> OnSuccess(Action<T> successAction)
         {
-            var retryTask = Clone();
-            retryTask.OnSuccessAction += (result, tryCount) => Task.Run(() => successAction(result));
-            return retryTask;
+            return OnSuccess((result, tryCount) => successAction(result));
         }
 
         /// <summary>
@@ -356,26 +393,32 @@ namespace Retry
         /// <returns></returns>
         public AsyncRetryTask<T> OnSuccess(Action<T, int> successAction)
         {
-            var retryTask = Clone();
-            retryTask.OnSuccessAction += (result, tryCount) => Task.Run(() => successAction(result, tryCount));
-            return retryTask;
+            return OnSuccess((result, tryCount) => Task.Run(() => successAction(result, tryCount)));
         }
 
         /// <summary>
-        /// Configures the action to take when the try action succeeds.
+        /// Configures the asynchronous action to take when the try action succeeds.
+        /// </summary>
+        /// <param name="successAction">The action to take on success.</param>
+        /// <returns></returns>
+        public AsyncRetryTask<T> OnSuccess(Func<Task> successAction)
+        {
+            return OnSuccess((result, tryCount) => successAction());
+        }
+
+        /// <summary>
+        /// Configures the asynchronous action to take when the try action succeeds.
         /// The result of the successful attempt is passed as parameter to the action.
         /// </summary>
         /// <param name="successAction">The action to take on success.</param>
         /// <returns></returns>
         public AsyncRetryTask<T> OnSuccess(Func<T, Task> successAction)
         {
-            var retryTask = Clone();
-            retryTask.OnSuccessAction += (result, tryCount) => successAction(result);
-            return retryTask;
+            return OnSuccess((result, tryCount) => successAction(result));
         }
 
         /// <summary>
-        /// Configures the action to take when the try action succeeds.
+        /// Configures the asynchronous action to take when the try action succeeds.
         /// The result of the successful attempt and the total count of attempts 
         /// are passed as parameters to the action. This count includes the 
         /// final successful one.

--- a/RetryHelper/AsyncRetryTaskOfT.cs
+++ b/RetryHelper/AsyncRetryTaskOfT.cs
@@ -134,14 +134,29 @@ namespace Retry
         }
 
         /// <summary>
-        ///   Retries the task until the specified exception is not thrown during the task execution.
+        ///   Retries the task until the specified exception or any derived exception is not thrown during the task execution.
         ///   Any other exception thrown is re-thrown.
         /// </summary>
         /// <returns></returns>
         [DebuggerNonUserCode]
         public async Task<T> UntilNoException<TException>()
         {
-            ExpectedExceptionType = typeof(TException);
+            return await UntilNoException(typeof(TException));
+        }
+
+        /// <summary>
+        ///   Retries the task until the specified exception or any derived exception is not thrown during the task execution.
+        ///   Any other exception thrown is re-thrown.
+        /// </summary>
+        /// <returns></returns>
+        [DebuggerNonUserCode]
+        public async Task<T> UntilNoException(Type exceptionType)
+        {
+            if (!typeof(Exception).IsAssignableFrom(exceptionType))
+            {
+                throw new ArgumentException($"Parameter {nameof(exceptionType)} must be a type that is assignable to type System.Exception.", nameof(exceptionType));
+            }
+            ExpectedExceptionType = exceptionType;
             return await UntilNoException();
         }
 

--- a/RetryHelper/AsyncRetryTaskOfT.cs
+++ b/RetryHelper/AsyncRetryTaskOfT.cs
@@ -536,7 +536,10 @@ namespace Retry
 
             // If should continue, perform the OnFailure action and wait some time before next try.
             await InvokeCallback(OnFailureAction, result, TriedCount);
-            Thread.Sleep(TryInterval);
+            // Using Task.Delay instead of Thread.Sleep actually makes the interval less precise
+            // with ~15ms off. It could be ok for most retry scenarios where a lot of I/O operations
+            // take place, but further investigation might be needed.
+            await Task.Delay(TryInterval);
             return true;
         }
 

--- a/RetryHelper/Extensions.cs
+++ b/RetryHelper/Extensions.cs
@@ -72,6 +72,7 @@ namespace Retry
         /// <param name="action">The <see cref="Action"/> instance.</param>
         /// <param name="value">The return value of the <see cref="Func{TResult}"/> instance.</param>
         /// <returns></returns>
+        [Obsolete("This method will become internal in a future version.")]
         public static Func<TResult> MakeFunc<TResult>(this Action action, TResult value = default(TResult))
         {
             if (action == null)

--- a/RetryHelper/Properties/AssemblyInfo.cs
+++ b/RetryHelper/Properties/AssemblyInfo.cs
@@ -31,5 +31,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.2.0.0")]
-[assembly: AssemblyVersion("2.0.0.0")]
-[assembly: AssemblyFileVersion("2.0.0.0")]
+[assembly: AssemblyVersion("2.1.0.0")]
+[assembly: AssemblyFileVersion("2.1.0.0")]

--- a/RetryHelper/RetryHelper.cs
+++ b/RetryHelper/RetryHelper.cs
@@ -9,8 +9,14 @@ namespace Retry
     /// </summary>
     public class RetryHelper
     {
+        /// <summary>
+        /// The default name of the <see cref="System.Diagnostics.TraceSource"/> instance used.
+        /// </summary>
         public static readonly string DefaultTraceSourceName = "retryHelperTrace";
-        
+
+        /// <summary>
+        /// The <see cref="System.Diagnostics.TraceSource"/> instance used by this <see cref="RetryHelper"/> instance.
+        /// </summary>
         protected readonly TraceSource TraceSource;
 
         #region Singleton

--- a/RetryHelper/RetryHelper.cs
+++ b/RetryHelper/RetryHelper.cs
@@ -21,8 +21,7 @@ namespace Retry
 
         #region Singleton
 
-        private static readonly Lazy<RetryHelper> _instance =
-            new Lazy<RetryHelper>(() => new RetryHelper());
+        private static readonly Lazy<RetryHelper> _instance = new Lazy<RetryHelper>(() => new RetryHelper());
 
         /// <summary>
         /// Get the default <see cref="RetryHelper"/> instance which uses the default trace source name.
@@ -55,7 +54,7 @@ namespace Retry
         }
 
         /// <summary>
-        /// Gets or sets the default max try time.
+        /// Gets or sets the default max try time. Defaults to unlimited (<c>TimeSpan.MaxValue</c>).
         /// </summary>
         /// <value>
         /// The default max try time.
@@ -63,7 +62,7 @@ namespace Retry
         public TimeSpan DefaultMaxTryTime { get; set; }
 
         /// <summary>
-        /// Gets or sets the default try interval.
+        /// Gets or sets the default try interval. Defaults to 500 ms.
         /// </summary>
         /// <value>
         /// The default try interval.
@@ -71,7 +70,7 @@ namespace Retry
         public TimeSpan DefaultTryInterval { get; set; }
 
         /// <summary>
-        /// Gets or sets the default max try count.
+        /// Gets or sets the default max try count. Defaults to unlimited (<c>Int32.MaxValue</c>).
         /// </summary>
         /// <value>
         /// The default max try count.

--- a/RetryHelper/RetryTask.cs
+++ b/RetryHelper/RetryTask.cs
@@ -160,7 +160,7 @@ namespace Retry
         /// <returns></returns>
         public RetryTask OnTimeout(Action<int> timeoutAction)
         {
-            return new RetryTask { Task = Task.OnTimeout(timeoutAction) };
+            return new RetryTask { Task = Task.OnTimeout((result, tryCount) => timeoutAction(tryCount)) };
         }
 
         /// <summary>
@@ -181,7 +181,7 @@ namespace Retry
         /// <returns></returns>
         public RetryTask OnFailure(Action<int> failureAction)
         {
-            return new RetryTask { Task = Task.OnFailure(failureAction) };
+            return new RetryTask { Task = Task.OnFailure((result, tryCount) => failureAction(tryCount)) };
         }
 
         /// <summary>
@@ -203,7 +203,7 @@ namespace Retry
         /// <returns></returns>
         public RetryTask OnSuccess(Action<int> successAction)
         {
-            return new RetryTask { Task = Task.OnSuccess(successAction) };
+            return new RetryTask { Task = Task.OnSuccess((result, tryCount) => successAction(tryCount)) };
         }
     }
 }

--- a/RetryHelper/RetryTask.cs
+++ b/RetryHelper/RetryTask.cs
@@ -149,7 +149,18 @@ namespace Retry
         /// <returns></returns>
         public RetryTask OnTimeout(Action timeoutAction)
         {
-            return new RetryTask { Task = Task.OnTimeout(t => timeoutAction()) };
+            return new RetryTask { Task = Task.OnTimeout(timeoutAction) };
+        }
+
+        /// <summary>
+        /// Configures the action to take when the try action timed out before success. 
+        /// The total count of attempts is passed as parameter to the <paramref name="timeoutAction"/>.
+        /// </summary>
+        /// <param name="timeoutAction">The action to take on timeout.</param>
+        /// <returns></returns>
+        public RetryTask OnTimeout(Action<int> timeoutAction)
+        {
+            return new RetryTask { Task = Task.OnTimeout(timeoutAction) };
         }
 
         /// <summary>
@@ -159,18 +170,18 @@ namespace Retry
         /// <returns></returns>
         public RetryTask OnFailure(Action failureAction)
         {
-            return new RetryTask { Task = Task.OnFailure(t => failureAction()) };
+            return new RetryTask { Task = Task.OnFailure(failureAction) };
         }
 
         /// <summary>
         /// Configures the action to take after each time the try action fails and before the next try. 
-        /// The total count of try that has attempted will be passed as parameters.
+        /// The total count of attempts so far is passed as parameter to the <paramref name="failureAction"/>.
         /// </summary>
         /// <param name="failureAction">The action to take on failure.</param>
         /// <returns></returns>
         public RetryTask OnFailure(Action<int> failureAction)
         {
-            return new RetryTask { Task = Task.OnFailure((result, tryCount) => failureAction(tryCount)) };
+            return new RetryTask { Task = Task.OnFailure(failureAction) };
         }
 
         /// <summary>
@@ -180,7 +191,19 @@ namespace Retry
         /// <returns></returns>
         public RetryTask OnSuccess(Action successAction)
         {
-            return new RetryTask { Task = Task.OnSuccess(t => successAction()) };
+            return new RetryTask { Task = Task.OnSuccess(successAction) };
+        }
+
+        /// <summary>
+        /// Configures the action to take when the try action succeeds.
+        /// The total count of attempts is passed as parameter to the <paramref name="successAction"/>.
+        /// This count includes the final successful one.
+        /// </summary>
+        /// <param name="successAction">The action to take on success.</param>
+        /// <returns></returns>
+        public RetryTask OnSuccess(Action<int> successAction)
+        {
+            return new RetryTask { Task = Task.OnSuccess(successAction) };
         }
     }
 }

--- a/RetryHelper/RetryTask.cs
+++ b/RetryHelper/RetryTask.cs
@@ -41,6 +41,9 @@ namespace Retry
                 maxTryTime, maxTryCount, tryInterval);
         }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="RetryTask"/> class.
+        /// </summary>
         protected RetryTask()
         {
         }
@@ -68,7 +71,7 @@ namespace Retry
         }
 
         /// <summary>
-        ///   Retries the task until the specified exception is not thrown during the task execution.
+        ///   Retries the task until the specified exception or any derived exception is not thrown during the task execution.
         ///   Any other exception thrown is re-thrown.
         /// </summary>
         /// <returns></returns>
@@ -76,6 +79,17 @@ namespace Retry
         public void UntilNoException<TException>()
         {
             Task.UntilNoException<TException>();
+        }
+
+        /// <summary>
+        ///   Retries the task until the specified exception or any derived exception is not thrown during the task execution.
+        ///   Any other exception thrown is re-thrown.
+        /// </summary>
+        /// <returns></returns>
+        [DebuggerNonUserCode]
+        public void UntilNoException(Type exceptionType)
+        {
+            Task.UntilNoException(exceptionType);
         }
 
         /// <summary>

--- a/RetryHelper/RetryTask.cs
+++ b/RetryHelper/RetryTask.cs
@@ -8,12 +8,24 @@ namespace Retry
     /// </summary>
     public class RetryTask
     {
+        /// <summary>
+        /// The default time interval to wait between each retry attempt. Defaults to 500 ms.
+        /// </summary>
         public static readonly TimeSpan DefaultTryInterval = TimeSpan.FromMilliseconds(500);
 
+        /// <summary>
+        /// The default max try time limit. Defaults to unlimited (<c>TimeSpan.MaxValue</c>).
+        /// </summary>
         public static readonly TimeSpan DefaultMaxTryTime = TimeSpan.MaxValue;
 
+        /// <summary>
+        /// The default max try count limit. Defaults to unlimited (<c>Int32.MaxValue</c>).
+        /// </summary>
         public static readonly int DefaultMaxTryCount = int.MaxValue;
 
+        /// <summary>
+        /// The underlying parameterized <see cref="RetryTask{T}"/> instance.
+        /// </summary>
         protected RetryTask<int> Task;
 
         /// <summary>

--- a/RetryHelper/RetryTask.cs
+++ b/RetryHelper/RetryTask.cs
@@ -35,7 +35,9 @@ namespace Retry
         /// <param name="traceSource">The trace source.</param>
         public RetryTask(Action task, TraceSource traceSource)
         {
+#pragma warning disable CS0618 // Type or member is obsolete
             Task = new RetryTask<int>(task.MakeFunc<int>(), traceSource);
+#pragma warning restore CS0618 // Type or member is obsolete
         }
 
         /// <summary>
@@ -49,8 +51,10 @@ namespace Retry
         public RetryTask(Action task, TraceSource traceSource,
             TimeSpan maxTryTime, int maxTryCount, TimeSpan tryInterval)
         {
+#pragma warning disable CS0618 // Type or member is obsolete
             Task = new RetryTask<int>(task.MakeFunc<int>(), traceSource,
                 maxTryTime, maxTryCount, tryInterval);
+#pragma warning restore CS0618 // Type or member is obsolete
         }
 
         /// <summary>

--- a/RetryHelper/RetryTaskOfT.cs
+++ b/RetryHelper/RetryTaskOfT.cs
@@ -327,9 +327,9 @@ namespace Retry
                     // Perform the try action.
                     result = Task();
                 }
-                catch(Exception ex)
+                catch (Exception ex)
                 {
-                    if(ShouldThrow(ex))
+                    if (ShouldThrow(ex))
                     {
                         throw;
                     }
@@ -338,14 +338,14 @@ namespace Retry
                     continue;
                 }
 
-                if(EndCondition(result))
+                if (EndCondition(result))
                 {
                     TraceSource.TraceVerbose("Trying succeeded after time {0} and total try count {1}.",
                         Stopwatch.Elapsed, TriedCount + 1);
                     OnSuccessAction(result, TriedCount + 1);
                     return result;
                 }
-            } while(ShouldContinue(result));
+            } while (ShouldContinue(result));
 
             // Should not continue. 
             OnTimeoutAction(result, TriedCount);
@@ -355,7 +355,7 @@ namespace Retry
         private bool ShouldThrow(Exception exception)
         {
             // If exception is not recoverable,
-            if(exception is OutOfMemoryException || exception is AccessViolationException ||
+            if (exception is OutOfMemoryException || exception is AccessViolationException ||
                 // or exception is not expected or not of expected type.
                 !RetryOnException || !ExpectedExceptionType.IsInstanceOfType(exception))
             {
@@ -369,13 +369,13 @@ namespace Retry
 
         private bool ShouldContinue(T result)
         {
-            if(Stopwatch.Elapsed >= MaxTryTime)
+            if (Stopwatch.Elapsed >= MaxTryTime)
             {
                 TimeoutErrorMsg = string.Format(CultureInfo.InvariantCulture,
                     "The maximum try time {0} for the operation has been exceeded.", MaxTryTime);
                 return false;
             }
-            if(++TriedCount >= MaxTryCount)
+            if (++TriedCount >= MaxTryCount)
             {
                 TimeoutErrorMsg = string.Format(CultureInfo.InvariantCulture,
                     "The maximum try count {0} for the operation has been exceeded.", MaxTryCount);

--- a/RetryHelper/RetryTaskOfT.cs
+++ b/RetryHelper/RetryTaskOfT.cs
@@ -100,14 +100,29 @@ namespace Retry
         }
 
         /// <summary>
-        ///   Retries the task until the specified exception is not thrown during the task execution.
+        ///   Retries the task until the specified exception or any derived exception is not thrown during the task execution.
         ///   Any other exception thrown is re-thrown.
         /// </summary>
         /// <returns></returns>
         [DebuggerNonUserCode]
         public T UntilNoException<TException>()
         {
-            ExpectedExceptionType = typeof(TException);
+            return UntilNoException(typeof(TException));
+        }
+
+        /// <summary>
+        ///   Retries the task until the specified exception or any derived exception is not thrown during the task execution.
+        ///   Any other exception thrown is re-thrown.
+        /// </summary>
+        /// <returns></returns>
+        [DebuggerNonUserCode]
+        public T UntilNoException(Type exceptionType)
+        {
+            if (!typeof(Exception).IsAssignableFrom(exceptionType))
+            {
+                throw new ArgumentException($"Parameter {nameof(exceptionType)} must be a type that is assignable to type System.Exception.", nameof(exceptionType));
+            }
+            ExpectedExceptionType = exceptionType;
             return UntilNoException();
         }
 

--- a/RetryHelper/RetryTaskOfT.cs
+++ b/RetryHelper/RetryTaskOfT.cs
@@ -183,6 +183,16 @@ namespace Retry
         }
 
         /// <summary>
+        /// Configures the action to take when the try action timed out before success.
+        /// </summary>
+        /// <param name="timeoutAction">The action to take on timeout.</param>
+        /// <returns></returns>
+        public RetryTask<T> OnTimeout(Action timeoutAction)
+        {
+            return OnTimeout((result, tryCount) => timeoutAction());
+        }
+
+        /// <summary>
         /// Configures the action to take when the try action timed out before success. 
         /// The result of the last failed attempt is passed as parameter to the action.
         /// For <see cref="UntilNoException"/>, the parameter passed to the action 
@@ -192,16 +202,14 @@ namespace Retry
         /// <returns></returns>
         public RetryTask<T> OnTimeout(Action<T> timeoutAction)
         {
-            var retryTask = Clone();
-            retryTask.OnTimeoutAction += (result, tryCount) => timeoutAction(result);
-            return retryTask;
+            return OnTimeout((result, tryCount) => timeoutAction(result));
         }
 
         /// <summary>
         /// Configures the action to take when the try action timed out before success. 
         /// The result of the last failed attempt and the total count of attempts 
         /// are passed as parameters to the action.
-        /// For <see cref="UntilNoException"/>, the parameter passed to the action 
+        /// For <see cref="UntilNoException"/>, the first parameter passed to the action 
         /// is always <c>default(T)</c>
         /// </summary>
         /// <param name="timeoutAction">The action to take on timeout.</param>
@@ -215,15 +223,23 @@ namespace Retry
 
         /// <summary>
         /// Configures the action to take after each time the try action fails and before the next try. 
+        /// </summary>
+        /// <param name="failureAction">The action to take on failure.</param>
+        /// <returns></returns>
+        public RetryTask<T> OnFailure(Action failureAction)
+        {
+            return OnFailure((result, tryCount) => failureAction());
+        }
+
+        /// <summary>
+        /// Configures the action to take after each time the try action fails and before the next try. 
         /// The result of the failed try action will be passed as parameter to the action.
         /// </summary>
         /// <param name="failureAction">The action to take on failure.</param>
         /// <returns></returns>
         public RetryTask<T> OnFailure(Action<T> failureAction)
         {
-            var retryTask = Clone();
-            retryTask.OnFailureAction += (result, tryCount) => failureAction(result);
-            return retryTask;
+            return OnFailure((result, tryCount) => failureAction(result));
         }
 
         /// <summary>
@@ -242,15 +258,23 @@ namespace Retry
 
         /// <summary>
         /// Configures the action to take when the try action succeeds.
+        /// </summary>
+        /// <param name="successAction">The action to take on success.</param>
+        /// <returns></returns>
+        public RetryTask<T> OnSuccess(Action successAction)
+        {
+            return OnSuccess((result, tryCount) => successAction());
+        }
+
+        /// <summary>
+        /// Configures the action to take when the try action succeeds.
         /// The result of the successful attempt is passed as parameter to the action.
         /// </summary>
         /// <param name="successAction">The action to take on success.</param>
         /// <returns></returns>
         public RetryTask<T> OnSuccess(Action<T> successAction)
         {
-            var retryTask = Clone();
-            retryTask.OnSuccessAction += (result, tryCount) => successAction(result);
-            return retryTask;
+            return OnSuccess((result, tryCount) => successAction(result));
         }
 
         /// <summary>

--- a/Samples/Properties/AssemblyInfo.cs
+++ b/Samples/Properties/AssemblyInfo.cs
@@ -31,5 +31,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.2.0.0")]
-[assembly: AssemblyVersion("2.0.0.0")]
-[assembly: AssemblyFileVersion("2.0.0.0")]
+[assembly: AssemblyVersion("2.1.0.0")]
+[assembly: AssemblyFileVersion("2.1.0.0")]

--- a/Tests/Async/OnFailureAsyncTest.cs
+++ b/Tests/Async/OnFailureAsyncTest.cs
@@ -20,6 +20,19 @@ namespace Tests
 
         [Test]
         [Timeout(1000)]
+        public async Task TestOnFailureWithNoParameter()
+        {
+            var times = 5;
+            var generator = new Generator(times);
+            var onFailureTriggered = 0;
+            await _target.TryAsync(() => generator.Next())
+                .OnFailure(() => onFailureTriggered++)
+                .Until(t => t);
+            Assert.That(onFailureTriggered, Is.EqualTo(times));
+        }
+
+        [Test]
+        [Timeout(1000)]
         public async Task TestOnFailureAfterFiveTimesAsync()
         {
             var times = 5;
@@ -58,13 +71,26 @@ namespace Tests
 
         [Test]
         [Timeout(1000)]
+        public async Task TestOnFailureAsyncWithNoParameterAsync()
+        {
+            var times = 5;
+            var generator = new Generator(times);
+            var onFailureTriggered = 0;
+            await _target.TryAsync(() => generator.Next())
+                .OnFailure(async () => await Task.Run(() => onFailureTriggered++))
+                .Until(t => t);
+            Assert.That(onFailureTriggered, Is.EqualTo(times));
+        }
+
+        [Test]
+        [Timeout(1000)]
         public async Task TestOnFailureShouldNotFireIfSucceedAtFirstTimeAsync()
         {
             var times = 0;
             var generator = new Generator(times);
             var onFailureTriggered = 0;
             await _target.TryAsync(() => generator.Next())
-                .OnFailure(t => onFailureTriggered++)
+                .OnFailure(() => onFailureTriggered++)
                 .Until(t => t);
             Assert.That(onFailureTriggered, Is.EqualTo(0));
         }

--- a/Tests/Async/OnFailureAsyncTest.cs
+++ b/Tests/Async/OnFailureAsyncTest.cs
@@ -134,7 +134,7 @@ namespace Tests
         }
 
         [Test]
-        [Timeout(1000)]
+        [Timeout(4000)]
         public async Task TestMultipleOnFailureAsync()
         {
             var times = 5;
@@ -142,13 +142,15 @@ namespace Tests
             var onFailureTriggered1 = 0;
             var onFailureTriggered2 = 0;
             await _target.TryAsync(() => generator.Next())
-                .OnFailure(t =>
+                .OnFailure(async t =>
                 {
+                    await Task.Delay(500);
                     Assert.That(t, Is.False);
                     onFailureTriggered1++;
                 })
-                .OnFailure(t =>
+                .OnFailure(async t =>
                 {
+                    await Task.Delay(50);
                     Assert.That(t, Is.False);
                     onFailureTriggered2++;
                 })

--- a/Tests/Async/OnSuccessAsyncTest.cs
+++ b/Tests/Async/OnSuccessAsyncTest.cs
@@ -19,13 +19,46 @@ namespace Tests
 
         [Test]
         [Timeout(1000)]
+        public async Task TestOnSuccessWithNoParameterAsync()
+        {
+            var times = 5;
+            var generator = new Generator(times);
+            var onSuccessTriggered = false;
+            await _target.TryAsync(() => generator.Next())
+                .OnSuccess(() => onSuccessTriggered = true)
+                .Until(t => t);
+            Assert.That(onSuccessTriggered, Is.True);
+        }
+
+        [Test]
+        [Timeout(1000)]
         public async Task TestOnSuccessAfterFiveTimesAsync()
         {
             var times = 5;
             var generator = new Generator(times);
             var onSuccessTriggered = false;
             await _target.TryAsync(() => generator.Next())
-                .OnSuccess(t => onSuccessTriggered = true)
+                .OnSuccess(t => {
+                    Assert.IsTrue(t);
+                    onSuccessTriggered = true;
+                })
+                .Until(t => t);
+            Assert.That(onSuccessTriggered, Is.True);
+        }
+
+        [Test]
+        [Timeout(1000)]
+        public async Task TestOnSuccessAsyncWithNoParameterAsync()
+        {
+            var times = 5;
+            var generator = new Generator(times);
+            var onSuccessTriggered = false;
+            await _target.TryAsync(() => generator.Next())
+                .OnSuccess(async () =>
+                {
+                    await Task.Delay(100);
+                    onSuccessTriggered = true;
+                })
                 .Until(t => t);
             Assert.That(onSuccessTriggered, Is.True);
         }
@@ -41,6 +74,7 @@ namespace Tests
                 .OnSuccess(async t =>
                 {
                     await Task.Delay(100);
+                    Assert.IsTrue(t);
                     onSuccessTriggered = true;
                 })
                 .Until(t => t);

--- a/Tests/Async/OnSuccessAsyncTest.cs
+++ b/Tests/Async/OnSuccessAsyncTest.cs
@@ -114,7 +114,7 @@ namespace Tests
         }
 
         [Test]
-        [Timeout(1000)]
+        [Timeout(4000)]
         public async Task TestMultipleOnSuccessAsync()
         {
             var times = 5;
@@ -122,10 +122,19 @@ namespace Tests
             var onSuccessTriggered1 = false;
             var onSuccessTriggered2 = false;
             await _target.TryAsync(() => generator.Next())
-                   .OnSuccess(t => onSuccessTriggered1 = true)
-                   .OnSuccess(t => onSuccessTriggered2 = true)
+                   .OnSuccess(async t =>
+                   {
+                       await Task.Delay(400);
+                       onSuccessTriggered1 = true;
+                   })
+                   .OnSuccess(async t =>
+                   {
+                       await Task.Delay(50);
+                       onSuccessTriggered2 = true;
+                   })
                    .Until(t => t);
             Assert.That(onSuccessTriggered1, Is.True);
+            Console.WriteLine("AA");
             Assert.That(onSuccessTriggered2, Is.True);
         }
     }

--- a/Tests/Async/OnTimeoutAsyncTest.cs
+++ b/Tests/Async/OnTimeoutAsyncTest.cs
@@ -23,11 +23,24 @@ namespace Tests
         {
             var times = 5;
             var generator = new Generator(times);
-            var onTimeoutTriggered = false;
             await _target.TryAsync(() => generator.Next())
-                   .OnTimeout(t => onTimeoutTriggered = true)
+                   .OnTimeout(() => Assert.Fail())
                    .Until(t => t);
-            Assert.That(onTimeoutTriggered, Is.False);
+        }
+
+        [Test]
+        [Timeout(1000)]
+        public void TestOnTimeoutWithNoParameterAsync()
+        {
+            var times = 5;
+            var generator = new Generator(times);
+            var onTimeoutTriggered = false;
+            Assert.ThrowsAsync<TimeoutException>(() =>
+                _target.TryAsync(() => generator.Next())
+                    .WithMaxTryCount(times - 1)
+                    .OnTimeout(() => onTimeoutTriggered = true)
+                    .Until(t => t));
+            Assert.That(onTimeoutTriggered, Is.True);
         }
 
         [Test]
@@ -40,7 +53,11 @@ namespace Tests
             Assert.ThrowsAsync<TimeoutException>(() =>
                 _target.TryAsync(() => generator.Next())
                     .WithMaxTryCount(times - 1)
-                    .OnTimeout(t => onTimeoutTriggered = true)
+                    .OnTimeout(t =>
+                    {
+                        Assert.IsFalse(t);
+                        onTimeoutTriggered = true;
+                    })
                     .Until(t => t));
             Assert.That(onTimeoutTriggered, Is.True);
         }
@@ -55,9 +72,29 @@ namespace Tests
             Assert.ThrowsAsync<TimeoutException>(() =>
                 _target.TryAsync(() => generator.Next())
                     .WithMaxTryCount(times - 1)
+                    .OnTimeout(async () =>
+                    {
+                        await Task.Delay(100);
+                        onTimeoutTriggered = true;
+                    })
+                    .Until(t => t));
+            Assert.That(onTimeoutTriggered, Is.True);
+        }
+
+        [Test]
+        [Timeout(1000)]
+        public void TestOnTimeoutAsyncWithNoParameterAsync()
+        {
+            var times = 5;
+            var generator = new Generator(times);
+            var onTimeoutTriggered = false;
+            Assert.ThrowsAsync<TimeoutException>(() =>
+                _target.TryAsync(() => generator.Next())
+                    .WithMaxTryCount(times - 1)
                     .OnTimeout(async t =>
                     {
                         await Task.Delay(100);
+                        Assert.IsFalse(t);
                         onTimeoutTriggered = true;
                     })
                     .Until(t => t));

--- a/Tests/Async/OnTimeoutAsyncTest.cs
+++ b/Tests/Async/OnTimeoutAsyncTest.cs
@@ -24,8 +24,8 @@ namespace Tests
             var times = 5;
             var generator = new Generator(times);
             await _target.TryAsync(() => generator.Next())
-                   .OnTimeout(() => Assert.Fail())
-                   .Until(t => t);
+                .OnTimeout(() => Assert.Fail())
+                .Until(t => t);
         }
 
         [Test]
@@ -131,10 +131,18 @@ namespace Tests
             var onTimeoutTriggered2 = false;
             Assert.ThrowsAsync<TimeoutException>(() =>
                 _target.TryAsync(() => generator.Next())
-                       .WithMaxTryCount(times - 1)
-                       .OnTimeout(t => onTimeoutTriggered1 = true)
-                       .OnTimeout(t => onTimeoutTriggered2 = true)
-                       .Until(t => t));
+                    .WithMaxTryCount(times - 1)
+                    .OnTimeout(async () =>
+                    {
+                        await Task.Delay(400);
+                        onTimeoutTriggered1 = true;
+                    })
+                    .OnTimeout(async () =>
+                    {
+                        await Task.Delay(50);
+                        onTimeoutTriggered2 = true;
+                    })
+                    .Until(t => t));
             Assert.That(onTimeoutTriggered1, Is.True);
             Assert.That(onTimeoutTriggered2, Is.True);
         }

--- a/Tests/Async/TryUntilNoExceptionAsyncTest.cs
+++ b/Tests/Async/TryUntilNoExceptionAsyncTest.cs
@@ -62,6 +62,20 @@ namespace Tests
 
         [Test]
         [Timeout(2000)]
+        public async Task TestTryUntilNoExceptionOfTypePassedAsParameterAfterFiveTimesAsync()
+        {
+            var times = 10;
+            var generator = new Generator(times, true);
+            bool result = false;
+            Assert.That(await RetryHelperTest.MeasureTime(async () =>
+                result = await _target.Try(() => generator.NextAsync()).UntilNoException(typeof(ApplicationException))),
+                Is.EqualTo(RetryHelperTest.Interval * times).Within(RetryHelperTest.Tolerance));
+            Assert.That(generator.TriedTimes, Is.EqualTo(times + 1));
+            Assert.That(result, Is.True);
+        }
+
+        [Test]
+        [Timeout(2000)]
         public void TestTryUntilNoExceptionOfTypeHavingOtherExceptionAsync()
         {
             var times = 10;
@@ -70,6 +84,19 @@ namespace Tests
             bool result = false;
             Assert.ThrowsAsync<InvalidOperationException>(async () =>
                 result = await _target.Try(async () => await generator.NextAsync()).UntilNoException<ApplicationException>());
+            Assert.That(result, Is.False);
+        }
+
+        [Test]
+        [Timeout(2000)]
+        public void TestTryUntilNoExceptionOfTypePassedAsParameterHavingOtherExceptionAsync()
+        {
+            var times = 10;
+            var generator = new Generator(times, true);
+            generator.RandomExceptionType = true;
+            bool result = false;
+            Assert.ThrowsAsync<InvalidOperationException>(async () =>
+                result = await _target.Try(async () => await generator.NextAsync()).UntilNoException(typeof(ApplicationException)));
             Assert.That(result, Is.False);
         }
     }

--- a/Tests/Async/TryUntilNoExceptionAsyncTest.cs
+++ b/Tests/Async/TryUntilNoExceptionAsyncTest.cs
@@ -27,7 +27,7 @@ namespace Tests
             bool result = false;
             Assert.That(await RetryHelperTest.MeasureTime(async () =>
                 result = await _target.Try(async () => await generator.NextAsync()).UntilNoException()),
-                Is.EqualTo(RetryHelperTest.Interval * times).Within(RetryHelperTest.Tolerance));
+                Is.EqualTo(RetryHelperTest.Interval * times).Within(RetryHelperTest.AsyncTolerance));
             Assert.That(generator.TriedTimes, Is.EqualTo(times + 1));
             Assert.That(result, Is.True);
         }
@@ -41,7 +41,7 @@ namespace Tests
             bool result = false;
             Assert.That(await RetryHelperTest.MeasureTime(async () =>
                 result = await _target.Try(async () => await generator.NextAsync()).Until(t => t)),
-                Is.EqualTo(RetryHelperTest.Interval * times).Within(RetryHelperTest.Tolerance));
+                Is.EqualTo(RetryHelperTest.Interval * times).Within(RetryHelperTest.AsyncTolerance));
             Assert.That(generator.TriedTimes, Is.EqualTo(times + 1));
             Assert.That(result, Is.True);
         }
@@ -55,7 +55,7 @@ namespace Tests
             bool result = false;
             Assert.That(await RetryHelperTest.MeasureTime(async () =>
                 result = await _target.Try(async () => await generator.NextAsync()).UntilNoException<ApplicationException>()),
-                Is.EqualTo(RetryHelperTest.Interval * times).Within(RetryHelperTest.Tolerance));
+                Is.EqualTo(RetryHelperTest.Interval * times).Within(RetryHelperTest.AsyncTolerance));
             Assert.That(generator.TriedTimes, Is.EqualTo(times + 1));
             Assert.That(result, Is.True);
         }
@@ -69,7 +69,7 @@ namespace Tests
             bool result = false;
             Assert.That(await RetryHelperTest.MeasureTime(async () =>
                 result = await _target.Try(() => generator.NextAsync()).UntilNoException(typeof(ApplicationException))),
-                Is.EqualTo(RetryHelperTest.Interval * times).Within(RetryHelperTest.Tolerance));
+                Is.EqualTo(RetryHelperTest.Interval * times).Within(RetryHelperTest.AsyncTolerance));
             Assert.That(generator.TriedTimes, Is.EqualTo(times + 1));
             Assert.That(result, Is.True);
         }

--- a/Tests/OnFailureTest.cs
+++ b/Tests/OnFailureTest.cs
@@ -19,6 +19,22 @@ namespace Tests
 
         [Test]
         [Timeout(1000)]
+        public void TestOnFailureWithNoParameter()
+        {
+            var times = 5;
+            var generator = new Generator(times);
+            var onFailureTriggered = 0;
+            _target.Try(() => generator.Next())
+                .OnFailure(() =>
+                {
+                    onFailureTriggered++;
+                })
+                .Until(t => t);
+            Assert.That(onFailureTriggered, Is.EqualTo(times));
+        }
+
+        [Test]
+        [Timeout(1000)]
         public void TestOnFailureAfterFiveTimes()
         {
             var times = 5;

--- a/Tests/OnSuccessTest.cs
+++ b/Tests/OnSuccessTest.cs
@@ -18,13 +18,30 @@ namespace Tests
 
         [Test]
         [Timeout(1000)]
+        public void TestOnSuccessWithNoParameter()
+        {
+            var times = 5;
+            var generator = new Generator(times);
+            var onSuccessTriggered = false;
+            _target.Try(() => generator.Next())
+                   .OnSuccess(() => onSuccessTriggered = true)
+                   .Until(t => t);
+            Assert.That(onSuccessTriggered, Is.True);
+        }
+
+        [Test]
+        [Timeout(1000)]
         public void TestOnSuccessAfterFiveTimes()
         {
             var times = 5;
             var generator = new Generator(times);
             var onSuccessTriggered = false;
             _target.Try(() => generator.Next())
-                   .OnSuccess(t => onSuccessTriggered = true)
+                   .OnSuccess(t =>
+                   {
+                       Assert.IsTrue(t);
+                       onSuccessTriggered = true;
+                   })
                    .Until(t => t);
             Assert.That(onSuccessTriggered, Is.True);
         }
@@ -35,14 +52,12 @@ namespace Tests
         {
             var times = 5;
             var generator = new Generator(times);
-            var onSuccessTriggered = false;
             Assert.That(() =>
                 _target.Try(() => generator.Next())
                        .WithMaxTryCount(times - 1)
-                       .OnSuccess(t => onSuccessTriggered = true)
+                       .OnSuccess(t => Assert.Fail())
                        .Until(t => t),
                 Throws.TypeOf<TimeoutException>());
-            Assert.That(onSuccessTriggered, Is.False);
         }
 
         [Test]

--- a/Tests/OnTimeoutTest.cs
+++ b/Tests/OnTimeoutTest.cs
@@ -22,11 +22,25 @@ namespace Tests
         {
             var times = 5;
             var generator = new Generator(times);
-            var onTimeoutTriggered = false;
             _target.Try(() => generator.Next())
-                   .OnTimeout(t => onTimeoutTriggered = true)
+                   .OnTimeout(t => Assert.Fail())
                    .Until(t => t);
-            Assert.That(onTimeoutTriggered, Is.False);
+        }
+
+        [Test]
+        [Timeout(1000)]
+        public void TestOnTimeoutWithNoParameter()
+        {
+            var times = 5;
+            var generator = new Generator(times);
+            var onTimeoutTriggered = false;
+            Assert.That(() =>
+                _target.Try(() => generator.Next())
+                       .WithMaxTryCount(times - 1)
+                       .OnTimeout(() => onTimeoutTriggered = true)
+                       .Until(t => t),
+                Throws.TypeOf<TimeoutException>());
+            Assert.That(onTimeoutTriggered, Is.True);
         }
 
         [Test]
@@ -39,7 +53,11 @@ namespace Tests
             Assert.That(() =>
                 _target.Try(() => generator.Next())
                        .WithMaxTryCount(times - 1)
-                       .OnTimeout(t => onTimeoutTriggered = true)
+                       .OnTimeout(t =>
+                       {
+                           Assert.IsFalse(t);
+                           onTimeoutTriggered = true;
+                       })
                        .Until(t => t),
                 Throws.TypeOf<TimeoutException>());
             Assert.That(onTimeoutTriggered, Is.True);

--- a/Tests/Properties/AssemblyInfo.cs
+++ b/Tests/Properties/AssemblyInfo.cs
@@ -32,8 +32,8 @@ using NUnit.Framework;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.2.0.0")]
-[assembly: AssemblyVersion("2.0.0.0")]
-[assembly: AssemblyFileVersion("2.0.0.0")]
+[assembly: AssemblyVersion("2.1.0.0")]
+[assembly: AssemblyFileVersion("2.1.0.0")]
 
 // Allow test fixtures to run in parallel
 [assembly: Parallelizable(ParallelScope.Fixtures)]

--- a/Tests/RetryHelperTest.cs
+++ b/Tests/RetryHelperTest.cs
@@ -10,6 +10,12 @@ namespace Tests
     public sealed class RetryHelperTest
     {
         public const int Tolerance = 70;
+
+        /// <summary>
+        /// Async version is less precise.
+        /// </summary>
+        public const int AsyncTolerance = 200;
+
         public const int Interval = 100;
 
         public static long MeasureTime(Action action)

--- a/Tests/TryUntilNoExceptionTest.cs
+++ b/Tests/TryUntilNoExceptionTest.cs
@@ -61,6 +61,20 @@ namespace Tests
 
         [Test]
         [Timeout(2000)]
+        public void TestTryUntilNoExceptionOfTypePassedAsParameterAfterFiveTimes()
+        {
+            var times = 10;
+            var generator = new Generator(times, true);
+            bool result = false;
+            Assert.That(RetryHelperTest.MeasureTime(() =>
+                result = _target.Try(() => generator.Next()).UntilNoException(typeof(ApplicationException))),
+                Is.EqualTo(RetryHelperTest.Interval * times).Within(RetryHelperTest.Tolerance));
+            Assert.That(generator.TriedTimes, Is.EqualTo(times + 1));
+            Assert.That(result, Is.True);
+        }
+
+        [Test]
+        [Timeout(2000)]
         public void TestTryUntilNoExceptionOfTypeHavingOtherException()
         {
             var times = 10;
@@ -69,6 +83,20 @@ namespace Tests
             bool result = false;
             Assert.That(() =>
                 result = _target.Try(() => generator.Next()).UntilNoException<ApplicationException>(),
+                Throws.TypeOf<InvalidOperationException>());
+            Assert.That(result, Is.False);
+        }
+
+        [Test]
+        [Timeout(2000)]
+        public void TestTryUntilNoExceptionOfTypePassedAsParameterHavingOtherException()
+        {
+            var times = 10;
+            var generator = new Generator(times, true);
+            generator.RandomExceptionType = true;
+            bool result = false;
+            Assert.That(() =>
+                result = _target.Try(() => generator.Next()).UntilNoException(typeof(ApplicationException)),
                 Throws.TypeOf<InvalidOperationException>());
             Assert.That(result, Is.False);
         }


### PR DESCRIPTION
### v2.1.0 (2018/5/30)
* Supported passing exception type to `UntilNoException`
* Allowed `OnFailure`, `OnSuccess` and `OnTimeout` callbacks to take no parameter
* Fixed a bug that if multiple callbacks of the same type are registered with async retry tasks, only the last one is awaited
* Replaced `Thread.Sleep` with `Task.Delay` for `AsyncRetryTask`
* Made `Extensions.MakeFunc` obsolete which should not have been public